### PR TITLE
Update requirements for supporting higher sylius versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "description": "Iyzico payment plugin for Sylius applications",
     "license": "MIT",
     "require": {
-        "php": "^7.2",
-        "sylius/sylius": "^1.4",
+        "php": "^7.4 || ^8.0",
+        "sylius/sylius": "^1.4 || ~1.9.0 || ~1.10.0@beta",
         "iyzico/iyzipay-php": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Yeni versiyonlarda kullanabilmek için php ve sylius versiyonları düzenlendi. Sylius 1.10 üzerinde test edildi. Translationsların yüklenmemesi dışında herhangi bir sorun görülmedi. Bu problem de sylius'un dizin isimlendirmesinde değişikliğe gitmesinden kaynaklanıyor. Pluginlerde çoğul isimlendirme yerine tekil isimlendirme yapılması gerekiyormuş. (```messages.tr.yml``` yerine ```message.tr.yml``` gibi)